### PR TITLE
Home page had a unfilled Key Highlight Title and Key Highlight description

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,6 +15,10 @@ notification: Government officials will Never ask you to transfer money or
 sections:
   - hero:
       background: /images/home page_cropped.jpg
+      key_highlights:
+        - title: Harmony in Diversity
+          description: Seeking Common Ground
+          url: ""
   - infobar:
       subtitle: ABOUT THE GALLERY
       description: The HDG was set up by MHA in collaboration with community partners

--- a/index.md
+++ b/index.md
@@ -15,13 +15,6 @@ notification: Government officials will Never ask you to transfer money or
 sections:
   - hero:
       background: /images/home page_cropped.jpg
-      key_highlights:
-        - title: Key Highlight Title
-          description: Key Highlight description
-          url: ""
-        - title: Harmony in Diversity
-          description: Seeking Common Ground
-          url: ""
   - infobar:
       subtitle: ABOUT THE GALLERY
       description: The HDG was set up by MHA in collaboration with community partners

--- a/index.md
+++ b/index.md
@@ -15,10 +15,6 @@ notification: Government officials will Never ask you to transfer money or
 sections:
   - hero:
       background: /images/home page_cropped.jpg
-      key_highlights:
-        - title: Harmony in Diversity
-          description: Seeking Common Ground
-          url: ""
   - infobar:
       subtitle: ABOUT THE GALLERY
       description: The HDG was set up by MHA in collaboration with community partners

--- a/index.md
+++ b/index.md
@@ -19,6 +19,9 @@ sections:
         - title: Key Highlight Title
           description: Key Highlight description
           url: ""
+        - title: Harmony in Diversity
+          description: Key Highlight description
+          url: ""
   - infobar:
       subtitle: ABOUT THE GALLERY
       description: The HDG was set up by MHA in collaboration with community partners

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ sections:
           description: Key Highlight description
           url: ""
         - title: Harmony in Diversity
-          description: Key Highlight description
+          description: Seeking Common Ground
           url: ""
   - infobar:
       subtitle: ABOUT THE GALLERY


### PR DESCRIPTION
I tried to edit the page by adding adding the Key Highlight Title and description.  But when I stage it, the new title and descrition was staged but original unfilled title and descrition is not deleted. 